### PR TITLE
Reorganize README as an artifact catalog by category

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repository.
+
+This repository is a public library of reusable Claude Code artifacts. Each artifact type lives under its own `<type>/library/` directory (`skills/library/`, `hooks/library/`, `rules/library/`, `agents/library/`, `slash-commands/library/`) or, for environments, under `environments/library/` and `environments/templates/`. Every type also carries a short README describing its own layout, conventions, and installation.
+
+## README maintenance
+
+The root `README.md` is a **catalog organized by artifact category**, not a description of the directory tree. It deliberately has no "repository structure" section: a reader should meet the actual, useful artifacts first, then learn how to consume them.
+
+### Category order
+
+Present categories in this fixed order, skipping any that are currently empty:
+
+1. Environments
+2. Skills
+3. Rules
+4. Hooks
+5. Agents
+6. Slash commands
+
+The order is fixed even as categories come and go; when a category gains its first artifact it takes its slot in this sequence, and the categories that remain are shown in this same relative order.
+
+### A category appears only when it has content
+
+A category earns its own `##` section in the root README only when the repository actually contains at least one artifact of that type under the type's `library/` directory. A type whose `library/` holds no artifacts yet — only its own `README.md` — is omitted from the root catalog until its first artifact lands. The goal is that every section a reader sees points at something real they can use, never at an empty placeholder.
+
+### Section shape
+
+Each populated category is a `##` section that opens with a short intro: what the type is (linked to the relevant Claude Code documentation), where the artifacts live, and a link to that type's own README for conventions and installation. Under the intro, each individual artifact gets a `###` subsection whose heading is the artifact's identifier (the skill directory name, the hook filename, and so on). The subsection is a concise, benefit-first description of what the artifact does and when to reach for it, ending with a link to the artifact file itself. Supporting files that are not standalone artifacts (for example a shared helper used by several hooks) are mentioned within the relevant category rather than given their own subsection.
+
+### Keep the catalog in sync with the library
+
+Adding, renaming, or removing an artifact is one change together with the README update that reflects it — never a code change now and a doc fix later. On every such change, harmonize the catalog with a three-part edit: ADD the new artifact's `###` subsection (and, when it is the first artifact of its type, add the whole category `##` section in its canonical slot); MODIFY the affected entries in place — a rename updates the artifact's `###` heading (its identifier) and its link path, and any change updates a description whose accuracy it affects; and REMOVE the subsection of a deleted artifact (and, when it was the last of its type, remove the now-empty category section). After editing, re-read the section end to end so it still reads as one coherent catalog rather than entries tacked on over time.

--- a/README.md
+++ b/README.md
@@ -8,56 +8,59 @@
 
 A public library of reusable Claude Code artifacts — skills, hooks, rules, environment configurations, agents, and slash commands — ready to drop into any Claude Code setup.
 
-## Overview
+Each artifact is a self-contained building block for [Claude Code](https://docs.claude.com/en/docs/claude-code/overview). You can consume it two ways: reference it from a single environment YAML file and let the [Claude Code Toolbox](https://github.com/alex-feel/claude-code-toolbox) install it for you (by raw URL or a shared `base-url`), or copy a rule, a hook, or a skill straight into your `~/.claude/` directory.
 
-Each artifact here is a self-contained building block for [Claude Code](https://docs.claude.com/en/docs/claude-code/overview). Artifacts are consumed declaratively by the [Claude Code Toolbox](https://github.com/alex-feel/claude-code-toolbox) environment configuration system: you reference an artifact from a single environment YAML file (by raw URL or a shared `base-url`) and the toolbox installs it for you. Artifacts are also usable on their own — copy a rule, a hook, or a skill straight into your `~/.claude/` directory.
+The sections below are a catalog of what is available today, grouped by artifact type. Each entry links to the artifact itself and to that type's README for conventions and installation details.
 
-## Repository structure
+## Skills
 
-```text
-.
-├── agents/library/            # subagent definitions (*.md)
-├── skills/library/            # skills (<skill-name>/SKILL.md + supporting files)
-├── hooks/
-│   ├── library/               # hook scripts (*.py)
-│   └── configs/               # hook configuration files (*.yaml)
-├── rules/library/             # rule files (*.md)
-├── slash-commands/library/    # slash command definitions (*.md)
-├── environments/
-│   ├── library/               # ready-to-use environment configs (*.yaml)
-│   └── templates/             # environment templates with placeholders (*.yaml)
-└── .github/                   # CI, issue forms, and the config validation model
-```
+[Agent Skills](https://docs.claude.com/en/docs/claude-code/skills) are multi-file packages that extend Claude Code with specialized, progressively disclosed capabilities. They live under [`skills/library/`](skills/library/); see [`skills/README.md`](skills/README.md) for the layout, conventions, and the two ways to install one.
 
-Every artifact type carries its own short README describing the layout and conventions: [skills](skills/README.md), [hooks](hooks/README.md), [rules](rules/README.md), [environments](environments/README.md), [agents](agents/README.md), [slash commands](slash-commands/README.md).
+### `dynamic-workflow-patterns`
+
+Pattern taxonomy and orchestration discipline for Claude Code dynamic workflows: which of the six workflow patterns fits a task, which agent roles to combine for each task family, which model to route to each role, and how to keep a run alive through server errors (for example HTTP 529), recover interrupted runs, and honor token budgets. Load it before authoring or running a Workflow script rather than hand-rolling one from memory. See [`skills/library/dynamic-workflow-patterns/SKILL.md`](skills/library/dynamic-workflow-patterns/SKILL.md).
+
+## Hooks
+
+[Hooks](https://docs.claude.com/en/docs/claude-code/hooks) run custom logic at Claude Code lifecycle events such as `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, and `SessionStart`. Scripts live under [`hooks/library/`](hooks/library/); see [`hooks/README.md`](hooks/README.md) for conventions and how to wire a hook to an event.
+
+### `idle_notification.py`
+
+Sends a desktop notification when Claude Code goes idle — waiting for your input after roughly 60 seconds of inactivity — so you can step away and be pulled back when Claude needs you. Wires to the `Notification` event with the `idle_prompt` matcher and falls back across notification backends per platform (desktop notifier, then a platform command-line fallback). See [`hooks/library/idle_notification.py`](hooks/library/idle_notification.py).
+
+### `status_line.py`
+
+Renders a colored Claude Code status line from the session JSON on stdin: model name, project directory, git branch (with `main`/`master` flagged in red), session id, added and removed line counts, compact 5h/7d rate-limit usage, an update-available indicator, and an optional custom suffix. Bracketed segments appear only when enabled and present. See [`hooks/library/status_line.py`](hooks/library/status_line.py).
+
+Both hooks read their optional YAML configuration through the shared [`hooks/library/hook_config_loader.py`](hooks/library/hook_config_loader.py) helper, so install it alongside whichever hook you use.
 
 ## Using an artifact
 
-Reference any file by its raw URL:
+Every artifact is a plain file addressable by its raw URL:
 
 ```text
 https://raw.githubusercontent.com/alex-feel/claude-code-artifacts-public/main/<path>
 ```
 
-For example, an environment YAML consumed by the toolbox might pull a rule and a subagent from here:
+The [Claude Code Toolbox](https://github.com/alex-feel/claude-code-toolbox) installs artifacts from a single environment YAML file. For example, wiring the idle-notification hook to the `Notification` event:
 
 ```yaml
-name: "My Environment"
-
-base-url: "https://raw.githubusercontent.com/alex-feel/claude-code-artifacts-public/main"
-
-agents:
-  - "agents/library/my-agent.md"
-
-rules:
-  - "rules/library/my-rule.md"
+hooks:
+  files:
+    - "https://raw.githubusercontent.com/alex-feel/claude-code-artifacts-public/main/hooks/library/idle_notification.py"
+    - "https://raw.githubusercontent.com/alex-feel/claude-code-artifacts-public/main/hooks/library/hook_config_loader.py"
+  events:
+    - event: "Notification"
+      matcher: "idle_prompt"
+      type: "command"
+      command: "idle_notification.py"
 ```
 
-See the toolbox [Environment Configuration Guide](https://github.com/alex-feel/claude-code-toolbox/blob/main/docs/environment-configuration-guide.md) for the full YAML reference (skills, hooks, MCP servers, settings, inheritance, and more).
+Skills install through the toolbox `skills` key or the `skills` CLI; each type's README shows the exact shape. See the toolbox [Environment Configuration Guide](https://github.com/alex-feel/claude-code-toolbox/blob/main/docs/environment-configuration-guide.md) for the full YAML reference (skills, hooks, MCP servers, settings, inheritance, and more).
 
 ## Adding a new artifact
 
-Read [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow. In short: place the artifact under the matching `<type>/library/` directory following that type's README, run the quality gate locally (`uv run pre-commit run --all-files`), and open a pull request. Environment configurations are additionally schema-validated in CI.
+Read [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow. In short: place the artifact under the matching `<type>/library/` directory following that type's README, update this README's catalog (see [CLAUDE.md](CLAUDE.md)), run the quality gate locally (`uv run pre-commit run --all-files`), and open a pull request. Environment configurations are additionally schema-validated in CI.
 
 ## Security
 


### PR DESCRIPTION
The README opened with a directory tree that described layout rather than the useful artifacts a reader wants to find first. It now leads with a catalog grouped by artifact type, listing only the categories that currently hold artifacts, with each entry linked to its file and to that type's README. A new CLAUDE.md records the catalog convention (the fixed category order, the omit-empty-categories rule, and the keep-in-sync edit) so future artifact changes keep the README and the library aligned.